### PR TITLE
add conda-forge/aws-sdk-cpp to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @h-vetinari @xhochy
+* @conda-forge/aws-sdk-cpp @xhochy

--- a/README.md
+++ b/README.md
@@ -239,6 +239,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@h-vetinari](https://github.com/h-vetinari/)
+* [@conda-forge/aws-sdk-cpp](https://github.com/conda-forge/aws-sdk-cpp/)
 * [@xhochy](https://github.com/xhochy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,5 +39,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - h-vetinari
     - xhochy
+    - conda-forge/aws-sdk-cpp


### PR DESCRIPTION
centralize maintainership for aws-* stack, as suggested in https://github.com/conda-forge/aws-c-http-feedstock/pull/84